### PR TITLE
use github token when getting latest release

### DIFF
--- a/install-cmdstan/README.md
+++ b/install-cmdstan/README.md
@@ -12,6 +12,11 @@ This action installs and caches [CmdStan](https://mc-stan.org/users/interfaces/c
 
 **Optional** Number of cores to use for building. Default `1`.
 
+### `github-token`
+
+**Optional** The GitHub token used to create an authenticated client. By default
+will use one automatically created by the github action.
+
 ## Example usage
 
 ```yaml

--- a/install-cmdstan/action.yml
+++ b/install-cmdstan/action.yml
@@ -12,10 +12,10 @@ inputs:
 
 runs:
   using: 'composite'
-  steps:
-    - env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  steps:
     - name: Determine CmdStan Version (Unix)
       if: runner.os != 'Windows' && inputs.cmdstan-version == 'latest'
       run: |

--- a/install-cmdstan/action.yml
+++ b/install-cmdstan/action.yml
@@ -16,12 +16,11 @@ inputs:
 
 runs:
   using: 'composite'
-  env:
-    GH_TOKEN: ${{ inputs.github-token }}
-
   steps:
     - name: Determine CmdStan Version (Unix)
       if: runner.os != 'Windows' && inputs.cmdstan-version == 'latest'
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         chmod +x ${{ github.action_path }}/scripts/get-latest-release.sh
         ${{ github.action_path }}/scripts/get-latest-release.sh
@@ -29,6 +28,8 @@ runs:
 
     - name: Determine CmdStan Version (Windows)
       if: runner.os == 'Windows' && inputs.cmdstan-version == 'latest'
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
       run: ${{ github.action_path }}\scripts\get-latest-release.ps1
       shell: pwsh
 

--- a/install-cmdstan/action.yml
+++ b/install-cmdstan/action.yml
@@ -9,11 +9,15 @@ inputs:
     description: 'Number of cores to use for building CmdStan'
     required: false
     default: '1'
+  github-token:
+    description: The GitHub token used to create an authenticated client
+    default: ${{ github.token }}
+    required: false
 
 runs:
   using: 'composite'
   env:
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GH_TOKEN: ${{ inputs.github-token }}
 
   steps:
     - name: Determine CmdStan Version (Unix)

--- a/install-cmdstan/action.yml
+++ b/install-cmdstan/action.yml
@@ -13,16 +13,19 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Determine CmdStan Version (Unix)
       if: runner.os != 'Windows' && inputs.cmdstan-version == 'latest'
       run: |
         chmod +x ${{ github.action_path }}/scripts/get-latest-release.sh
-        ${{ github.action_path }}/scripts/get-latest-release.sh ${{ secrets.GITHUB_TOKEN }}
+        ${{ github.action_path }}/scripts/get-latest-release.sh
       shell: bash
 
     - name: Determine CmdStan Version (Windows)
       if: runner.os == 'Windows' && inputs.cmdstan-version == 'latest'
-      run: ${{ github.action_path }}\scripts\get-latest-release.ps1 ${{ secrets.GITHUB_TOKEN }}
+      run: ${{ github.action_path }}\scripts\get-latest-release.ps1 ${{ env.GH_TOKEN }}
       shell: pwsh
 
     - name: Set CmdStan Version (Specified)

--- a/install-cmdstan/action.yml
+++ b/install-cmdstan/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: Determine CmdStan Version (Windows)
       if: runner.os == 'Windows' && inputs.cmdstan-version == 'latest'
-      run: ${{ github.action_path }}\scripts\get-latest-release.ps1 ${{ env.GH_TOKEN }}
+      run: ${{ github.action_path }}\scripts\get-latest-release.ps1
       shell: pwsh
 
     - name: Set CmdStan Version (Specified)

--- a/install-cmdstan/action.yml
+++ b/install-cmdstan/action.yml
@@ -13,16 +13,18 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Determine CmdStan Version (Unix)
       if: runner.os != 'Windows' && inputs.cmdstan-version == 'latest'
       run: |
         chmod +x ${{ github.action_path }}/scripts/get-latest-release.sh
-        ${{ github.action_path }}/scripts/get-latest-release.sh
+        ${{ github.action_path }}/scripts/get-latest-release.sh $GH_TOKEN
       shell: bash
 
     - name: Determine CmdStan Version (Windows)
       if: runner.os == 'Windows' && inputs.cmdstan-version == 'latest'
-      run: ${{ github.action_path }}\scripts\get-latest-release.ps1
+      run: ${{ github.action_path }}\scripts\get-latest-release.ps1 $GH_TOKEN
       shell: pwsh
 
     - name: Set CmdStan Version (Specified)

--- a/install-cmdstan/action.yml
+++ b/install-cmdstan/action.yml
@@ -13,18 +13,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Determine CmdStan Version (Unix)
       if: runner.os != 'Windows' && inputs.cmdstan-version == 'latest'
       run: |
         chmod +x ${{ github.action_path }}/scripts/get-latest-release.sh
-        ${{ github.action_path }}/scripts/get-latest-release.sh $GH_TOKEN
+        ${{ github.action_path }}/scripts/get-latest-release.sh ${{ secrets.GITHUB_TOKEN }}
       shell: bash
 
     - name: Determine CmdStan Version (Windows)
       if: runner.os == 'Windows' && inputs.cmdstan-version == 'latest'
-      run: ${{ github.action_path }}\scripts\get-latest-release.ps1 $GH_TOKEN
+      run: ${{ github.action_path }}\scripts\get-latest-release.ps1 ${{ secrets.GITHUB_TOKEN }}
       shell: pwsh
 
     - name: Set CmdStan Version (Specified)

--- a/install-cmdstan/scripts/get-latest-release.ps1
+++ b/install-cmdstan/scripts/get-latest-release.ps1
@@ -1,5 +1,8 @@
 # PowerShell script to fetch the latest CmdStan release version with enhanced retry logic
 
+# Get command line argument (token)
+$token=$args[0]
+
 # Initialize retry parameters
 $max_attempts = 10
 $wait_time = 5 # seconds
@@ -8,7 +11,7 @@ $version = $null
 for ($attempt = 1; $attempt -le $max_attempts; $attempt++) {
     try {
         # Using Invoke-RestMethod to fetch the latest release data
-        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop -Authentication Bearer -Token $token
         $version = $response.tag_name -replace '^v', '' # Remove 'v' from version if present
 
         # Check if the version is successfully retrieved

--- a/install-cmdstan/scripts/get-latest-release.ps1
+++ b/install-cmdstan/scripts/get-latest-release.ps1
@@ -7,7 +7,7 @@ $version = $null
 $token = $env:GH_TOKEN
 $auth_str = ""
 
-if (-not [string]::IsNullOrWhiteSpace($toke)) {
+if (-not [string]::IsNullOrWhiteSpace($token)) {
   auth_str = "-Authentication Bearer -Token $token"
 }
 

--- a/install-cmdstan/scripts/get-latest-release.ps1
+++ b/install-cmdstan/scripts/get-latest-release.ps1
@@ -8,7 +8,7 @@ $token = $env:GH_TOKEN
 $auth_str = ""
 
 if (-not [string]::IsNullOrWhiteSpace($token)) {
-  auth_str = "-Authentication Bearer -Token $token"
+  $auth_str = "-Authentication Bearer -Token $token"
 }
 
 for ($attempt = 1; $attempt -le $max_attempts; $attempt++) {

--- a/install-cmdstan/scripts/get-latest-release.ps1
+++ b/install-cmdstan/scripts/get-latest-release.ps1
@@ -1,8 +1,5 @@
 # PowerShell script to fetch the latest CmdStan release version with enhanced retry logic
 
-# Get command line argument (token)
-$token=$args[0]
-
 # Initialize retry parameters
 $max_attempts = 10
 $wait_time = 5 # seconds
@@ -11,7 +8,7 @@ $version = $null
 for ($attempt = 1; $attempt -le $max_attempts; $attempt++) {
     try {
         # Using Invoke-RestMethod to fetch the latest release data
-        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop -Authentication Bearer -Token $token
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop -Authentication Bearer -Token $env:GH_TOKEN
         $version = $response.tag_name -replace '^v', '' # Remove 'v' from version if present
 
         # Check if the version is successfully retrieved

--- a/install-cmdstan/scripts/get-latest-release.ps1
+++ b/install-cmdstan/scripts/get-latest-release.ps1
@@ -5,16 +5,17 @@ $max_attempts = 10
 $wait_time = 5 # seconds
 $version = $null
 $token = $env:GH_TOKEN
-$auth_str = ""
-
+$headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 if (-not [string]::IsNullOrWhiteSpace($token)) {
-  $auth_str = "-Authentication Bearer -Token $token"
+  $headers.Add('Accept','application/vnd.github+json')
+  $headers.Add('Authorization', -join('Bearer: ', $GH_TOKEN))
+  $headers.Add('X-GitHub-Api-Version','2022-11-28')
 }
 
 for ($attempt = 1; $attempt -le $max_attempts; $attempt++) {
     try {
         # Using Invoke-RestMethod to fetch the latest release data
-        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop $auth_str
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop -Header $headers
         $version = $response.tag_name -replace '^v', '' # Remove 'v' from version if present
 
         # Check if the version is successfully retrieved

--- a/install-cmdstan/scripts/get-latest-release.ps1
+++ b/install-cmdstan/scripts/get-latest-release.ps1
@@ -15,7 +15,7 @@ if (-not [string]::IsNullOrWhiteSpace($token)) {
 for ($attempt = 1; $attempt -le $max_attempts; $attempt++) {
     try {
         # Using Invoke-RestMethod to fetch the latest release data
-        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop -Header $headers
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop -Headers $headers
         $version = $response.tag_name -replace '^v', '' # Remove 'v' from version if present
 
         # Check if the version is successfully retrieved

--- a/install-cmdstan/scripts/get-latest-release.ps1
+++ b/install-cmdstan/scripts/get-latest-release.ps1
@@ -4,11 +4,17 @@
 $max_attempts = 10
 $wait_time = 5 # seconds
 $version = $null
+$token = $env:GH_TOKEN
+$auth_str = ""
+
+if (-not [string]::IsNullOrWhiteSpace($toke)) {
+  auth_str = "-Authentication Bearer -Token $token"
+}
 
 for ($attempt = 1; $attempt -le $max_attempts; $attempt++) {
     try {
         # Using Invoke-RestMethod to fetch the latest release data
-        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop -Authentication Bearer -Token $env:GH_TOKEN
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/stan-dev/cmdstan/releases/latest" -Method Get -ErrorAction Stop $auth_str
         $version = $response.tag_name -replace '^v', '' # Remove 'v' from version if present
 
         # Check if the version is successfully retrieved

--- a/install-cmdstan/scripts/get-latest-release.ps1
+++ b/install-cmdstan/scripts/get-latest-release.ps1
@@ -10,6 +10,8 @@ if (-not [string]::IsNullOrWhiteSpace($token)) {
   $headers.Add('Accept','application/vnd.github+json')
   $headers.Add('Authorization', -join('Bearer: ', $GH_TOKEN))
   $headers.Add('X-GitHub-Api-Version','2022-11-28')
+} else {
+  Write-Host "No authentication token found in the environment."
 }
 
 for ($attempt = 1; $attempt -le $max_attempts; $attempt++) {

--- a/install-cmdstan/scripts/get-latest-release.ps1
+++ b/install-cmdstan/scripts/get-latest-release.ps1
@@ -8,7 +8,7 @@ $token = $env:GH_TOKEN
 $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 if (-not [string]::IsNullOrWhiteSpace($token)) {
   $headers.Add('Accept','application/vnd.github+json')
-  $headers.Add('Authorization', -join('Bearer: ', $GH_TOKEN))
+  $headers.Add('Authorization', -join('Bearer: ', $token))
   $headers.Add('X-GitHub-Api-Version','2022-11-28')
 } else {
   Write-Host "No authentication token found in the environment."

--- a/install-cmdstan/scripts/get-latest-release.sh
+++ b/install-cmdstan/scripts/get-latest-release.sh
@@ -11,7 +11,6 @@ else
     exit 1
 fi
 
-token=$1
 retries=10
 wait_time=5
 status=0
@@ -22,7 +21,7 @@ for ((i=0; i<retries; i++)); do
     # Save the response body to a temporary file and capture HTTP status code separately
     response=$(curl -s -w "%{http_code}" -L -o temp.json \
         -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $token" \
+        -H "Authorization: Bearer $GH_TOKEN" \
         -H "X-GitHub-Api-Version: 2022-11-28" -o temp.json \
         https://api.github.com/repos/stan-dev/cmdstan/releases/latest)
     http_code=$(echo $response | tail -n1)  # Extract the HTTP status code

--- a/install-cmdstan/scripts/get-latest-release.sh
+++ b/install-cmdstan/scripts/get-latest-release.sh
@@ -11,6 +11,7 @@ else
     exit 1
 fi
 
+token=$1
 retries=10
 wait_time=5
 status=0
@@ -19,7 +20,11 @@ version=""
 for ((i=0; i<retries; i++)); do
     echo "Attempt $((i+1)) of $retries"
     # Save the response body to a temporary file and capture HTTP status code separately
-    response=$(curl -s -w "%{http_code}" -o temp.json https://api.github.com/repos/stan-dev/cmdstan/releases/latest)
+    response=$(curl -s -w "%{http_code}" -L -o temp.json \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $token" \
+        -H "X-GitHub-Api-Version: 2022-11-28" -o temp.json \
+        https://api.github.com/repos/stan-dev/cmdstan/releases/latest)
     http_code=$(echo $response | tail -n1)  # Extract the HTTP status code
     version=$(jq -r '.tag_name' temp.json | tr -d 'v')
     rm temp.json

--- a/install-cmdstan/scripts/get-latest-release.sh
+++ b/install-cmdstan/scripts/get-latest-release.sh
@@ -18,11 +18,17 @@ version=""
 
 for ((i=0; i<retries; i++)); do
     echo "Attempt $((i+1)) of $retries"
+    auth_str=""
+    if [ -n "${GH_TOKEN}" ]; then
+        ## we have a github token in the enviroment; set autentication string
+        auth_str+=" -H \"Accept: application/vnd.github+json\""
+        auth_str+=" -H \"Authorization: Bearer $GH_TOKEN\""
+        auth_str+=" -H \"X-GitHub-Api-Version: 2022-11-28\""
+    else
+        echo "No authentication token found in the environment."
+    fi
     # Save the response body to a temporary file and capture HTTP status code separately
-    response=$(curl -s -w "%{http_code}" -L -o temp.json \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $GH_TOKEN" \
-        -H "X-GitHub-Api-Version: 2022-11-28" -o temp.json \
+    response=$(curl -s -w "%{http_code}" -L -o temp.json $auth_str \
         https://api.github.com/repos/stan-dev/cmdstan/releases/latest)
     http_code=$(echo $response | tail -n1)  # Extract the HTTP status code
     version=$(jq -r '.tag_name' temp.json | tr -d 'v')

--- a/install-cmdstan/scripts/get-latest-release.sh
+++ b/install-cmdstan/scripts/get-latest-release.sh
@@ -28,7 +28,7 @@ for ((i=0; i<retries; i++)); do
         echo "No authentication token found in the environment."
     fi
     # Save the response body to a temporary file and capture HTTP status code separately
-    response=$(curl -s -w "%{http_code}" -L -o temp.json $auth_str \
+    response=$(eval curl -s -w "%{http_code}" -L -o temp.json $auth_str \
         https://api.github.com/repos/stan-dev/cmdstan/releases/latest)
     http_code=$(echo $response | tail -n1)  # Extract the HTTP status code
     version=$(jq -r '.tag_name' temp.json | tr -d 'v')


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

If this works it would address the issue mentioned in https://github.com/epiforecasts/EpiNow2/pull/769#issuecomment-2363736624 - possibly causing the same issue elsewhere? 

It tries to do so by sending a github token with the HTTP request to get the latest release version.

I have been able to test the unix version locally but not the windows one.

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
