### PR TITLE
26: rebuild cmdstan if using cache

### DIFF
--- a/install-cmdstan/action.yml
+++ b/install-cmdstan/action.yml
@@ -61,3 +61,9 @@ runs:
       run: |
         Rscript -e 'cmdstanr::set_cmdstan_path("~/.cmdstan/cmdstan-${{ env.CMDSTAN_VERSION }}")'
       shell: bash
+
+    - name: Rebuild CmdStan
+      if: ${{(steps.cache-cmdstan.outputs.cache-hit == 'true') && runner.os == 'macOS'}}
+      run: |
+        Rscript -e 'cmdstanr::rebuild_cmdstan()'
+      shell: bash


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #26 - not by addressing the issue in the title but by rebuilding cmdstan if it comes from the cache. This adds a minute of compilation time in https://github.com/epiforecasts/EpiNow2/actions/runs/13132145363/job/36639400979?pr=970 - alternative would be not to use the cache at all on macOS.
 
## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
